### PR TITLE
stop loss price 

### DIFF
--- a/Start to Finish Straddle System Automation.ipynb
+++ b/Start to Finish Straddle System Automation.ipynb
@@ -278,7 +278,7 @@
     "                \"side\":stop_loss_side,\n",
     "                \"productType\":product_type,\n",
     "                \"limitPrice\":0,\n",
-    "                \"stopPrice\":stop_price,\n",
+    "                \"stopPrice\":stop_loss_price,\n",
     "                \"validity\":\"DAY\",\n",
     "                \"disclosedQty\":0,\n",
     "                \"offlineOrder\":\"False\",\n",


### PR DESCRIPTION
on line 281; "stopPrice":stop_price
in the stop_loss_order function, "stop_price" is not defined